### PR TITLE
Fix for Prism and Litebeam 878

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2025-08-22
+
+### Added
+
+- Making antenna_gain and nol_* optional for support of 8.7.8 models as reported
+
 ## [0.3.0] - 2025-08-15
 
 ### Added

--- a/airos/data.py
+++ b/airos/data.py
@@ -370,7 +370,6 @@ class Remote(AirOSDataClass):
     tx_ratedata: list[int]
     tx_bytes: int
     rx_bytes: int
-    antenna_gain: int
     cable_loss: int
     ethlist: list[EthList]
     ipaddr: list[str]
@@ -385,6 +384,7 @@ class Remote(AirOSDataClass):
     gps: GPSData | None = (
         None  # Reported NanoStation 5AC 8.7.18 without GPS Core 150491
     )
+    antenna_gain: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
@@ -456,7 +456,6 @@ class Wireless(AirOSDataClass):
     compat_11n: int
     hide_essid: int
     apmac: str
-    antenna_gain: int
     frequency: int
     center1_freq: int
     dfs: int
@@ -469,8 +468,6 @@ class Wireless(AirOSDataClass):
     chanbw: int
     rx_chainmask: int
     tx_chainmask: int
-    nol_state: int
-    nol_timeout: int
     cac_state: int
     cac_timeout: int
     rx_idx: int
@@ -484,6 +481,9 @@ class Wireless(AirOSDataClass):
     sta: list[Station]
     sta_disconnected: list[Disconnected]
     mode: WirelessMode | None = None  # Investigate further (see WirelessMode in Remote)
+    nol_state: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
+    nol_timeout: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
+    antenna_gain: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.3.0"
+version         = "0.3.1"
 license         = "MIT"
 description     = "Ubiquity airOS module(s) for Python 3."
 readme          = "README.md"


### PR DESCRIPTION
As reported https://github.com/home-assistant/core/issues/150540#issuecomment-3214129601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added compatibility with 8.7.8 models.
  - Antenna gain is now optional where applicable.
  - Exposes Non-Occupancy List (NOL) state and timeout as optional fields.

- Documentation
  - Updated changelog with version 0.3.1 (2025-08-22) and noted new optional fields.

- Chores
  - Bumped project version to 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->