### PR TITLE
Make antenna gain and nol options optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3] - 2025-08-22
+
+### Changed
+
+- Made antenna_gain and nol_* optional for Prism and LiteBeam 8.7.8 support
+
 ## [0.4.2] - 2025-08-17
 
 ### Changed

--- a/airos/data.py
+++ b/airos/data.py
@@ -368,7 +368,6 @@ class Remote(AirOSDataClass):
     tx_ratedata: list[int]
     tx_bytes: int
     rx_bytes: int
-    antenna_gain: int
     cable_loss: int
     ethlist: list[EthList]
     ipaddr: list[str]
@@ -383,6 +382,7 @@ class Remote(AirOSDataClass):
     gps: GPSData | None = (
         None  # Reported NanoStation 5AC 8.7.18 without GPS Core 150491
     )
+    antenna_gain: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
@@ -454,7 +454,6 @@ class Wireless(AirOSDataClass):
     compat_11n: int
     hide_essid: int
     apmac: str
-    antenna_gain: int
     frequency: int
     center1_freq: int
     dfs: int
@@ -467,8 +466,6 @@ class Wireless(AirOSDataClass):
     chanbw: int
     rx_chainmask: int
     tx_chainmask: int
-    nol_state: int
-    nol_timeout: int
     cac_state: int
     cac_timeout: int
     rx_idx: int
@@ -482,6 +479,9 @@ class Wireless(AirOSDataClass):
     sta: list[Station]
     sta_disconnected: list[Disconnected]
     mode: WirelessMode | None = None  # Investigate further (see WirelessMode in Remote)
+    nol_state: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
+    nol_timeout: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
+    antenna_gain: int | None = None  # Reported on Prism 6.3.5? and LiteBeam 8.7.8
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.4.2"
+version         = "0.4.3"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Prism and LiteBeam devices on firmware 8.7.8 by allowing antenna gain and DFS/NOL-related values to be optional, preventing errors when absent.
* **Documentation**
  * Updated changelog with entry for version 0.4.3 (2025-08-22).
* **Chores**
  * Bumped version to 0.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->