### PR TITLE
Fix for reported LiteBeam signal in Disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.4] - 2025-08-29
+
+### Changed
+
+- Made signal in Disconnected optional as reported on LiteBeam 8.7.15
+
 ## [0.4.3] - 2025-08-22
 
 ### Changed
 
-- Made antenna_gain and nol_* optional for Prism and LiteBeam 8.7.8 support
+- Made antenna_gain and nol_* optional as reported on  Prism and LiteBeam 8.7.8 support
 
 ## [0.4.2] - 2025-08-17
 

--- a/airos/data.py
+++ b/airos/data.py
@@ -397,12 +397,12 @@ class Disconnected(AirOSDataClass):
 
     mac: str
     lastip: str
-    signal: int
     hostname: str
     platform: str
     reason_code: int
     disconnect_duration: int
     airos_connected: bool = False  # Mock add to determine Disconnected vs Station
+    signal: int | None = None  # Litebeam 5AC can have no signal
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.4.3"
+version         = "0.4.4"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved compatibility with devices that may not report signal strength while disconnected (e.g., certain LiteBeam firmware), preventing parsing failures and ensuring more robust status handling.

- Documentation
  - Updated changelog for 0.4.4 with clarified notes; removed an outdated bullet and refined wording for prior entries.

- Chores
  - Bumped version to 0.4.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->