### PR TITLE
Add support for NanoStation loco M900 in model mapping and IeeeMode enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.5] - 2026-04-28
+
+### Added
+
+- Add support for NanoAStation loco M900
+
 ## [0.6.4] - 2026-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add support for NanoAStation loco M900
+- Add support for NanoStation loco M900
 
 ## [0.6.4] - 2026-02-13
 

--- a/airos/data.py
+++ b/airos/data.py
@@ -148,6 +148,7 @@ class IeeeMode(Enum):
     _11ACVHT20 = "11ACVHT20"  # On a LiteBeam
     _11NAHT40MINUS = "11NAHT40MINUS"  # On a v6 XM
     _11NAHT40PLUS = "11NAHT40PLUS"  # On a v6 XW
+    _11NGHT20 = "11NGHT20"  # On a v6 XM 900 MHz device (NanoStation loco M900)
     # More to be added when known
 
 

--- a/airos/model_map.py
+++ b/airos/model_map.py
@@ -85,6 +85,7 @@ MANUAL_MODELS: dict[str, str] = {
     "LiteAP GPS": "LAP-GPS",  # Shortened name for airMAX Lite Access Point GPS
     "LiteBeam 5AC 23": "LBE-5AC-23",
     "NanoStation loco M5": "LocoM5",  # XM firmware version 6 - note the reversed names
+    "NanoStation loco M900 ": "LocoM900",  # XM firmware version 6, 900 MHz variant
 }
 
 MODELS: dict[str, str] = {**SITE_MODELS, **MANUAL_MODELS}

--- a/airos/model_map.py
+++ b/airos/model_map.py
@@ -85,7 +85,7 @@ MANUAL_MODELS: dict[str, str] = {
     "LiteAP GPS": "LAP-GPS",  # Shortened name for airMAX Lite Access Point GPS
     "LiteBeam 5AC 23": "LBE-5AC-23",
     "NanoStation loco M5": "LocoM5",  # XM firmware version 6 - note the reversed names
-    "NanoStation loco M900 ": "LocoM900",  # XM firmware version 6, 900 MHz variant
+    "NanoStation loco M900": "LocoM900",  # XM firmware version 6, 900 MHz variant
 }
 
 MODELS: dict[str, str] = {**SITE_MODELS, **MANUAL_MODELS}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.4"
+version         = "0.6.5"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"


### PR DESCRIPTION
Adds M900 legacy model to the models list. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for an additional IEEE 802.11n/NG wireless mode.
  * Extends device model recognition to include NanoStation loco M900.

* **Documentation**
  * Adds a 0.6.5 changelog entry noting the new device support.

* **Chores**
  * Bumps package version to 0.6.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->