### PR TITLE
Add exception for legacy v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.8] - 2026-05-26
+
+### Added
+
+- Introduce TLS adjustment for legacy v6 devices
+
 ## [0.6.7] - 2026-05-21
 
 ### Added

--- a/airos/base.py
+++ b/airos/base.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from http.cookies import SimpleCookie
 import json
 import logging
+from ssl import SSLError
 from typing import Any, Generic, TypeVar
 from urllib.parse import urlparse
 
@@ -27,6 +28,7 @@ from .exceptions import (
     AirOSDeviceConnectionError,
     AirOSKeyDataMissingError,
     AirOSMultipleMatchesFoundException,
+    AirOSTLSCompatibilityError,
     AirOSUrlNotFoundError,
 )
 from .model_map import UispAirOSProductMapper
@@ -308,6 +310,11 @@ class AirOS(ABC, Generic[AirOSDataModel]):
             if err.status == 404:
                 raise AirOSUrlNotFoundError from err
             raise AirOSConnectionSetupError from err
+        except aiohttp.ClientConnectorSSLError as err:
+            if _is_tls_compatibility_error(err):
+                _LOGGER.exception("TLS compatibility error during API call to %s", url)
+                raise AirOSTLSCompatibilityError from err
+            raise AirOSDeviceConnectionError from err
         except (TimeoutError, aiohttp.ClientError) as err:
             _LOGGER.exception("Error during API call to %s", url)
             raise AirOSDeviceConnectionError from err
@@ -512,3 +519,18 @@ class AirOS(ABC, Generic[AirOSDataModel]):
             ct_json=True,
             authenticated=True,
         )
+
+
+def _is_tls_compatibility_error(err: aiohttp.ClientConnectorSSLError) -> bool:
+    """Return True for known legacy airOS TLS handshake failures."""
+    if "SSLV3_ALERT_HANDSHAKE_FAILURE" in str(err):
+        return True
+
+    cause = err.__cause__
+    if isinstance(cause, SSLError):
+        message = str(cause).lower()
+        return (
+            "handshake failure" in message or "sslv3 alert handshake failure" in message
+        )
+
+    return False

--- a/airos/exceptions.py
+++ b/airos/exceptions.py
@@ -50,4 +50,4 @@ class AirOSMultipleMatchesFoundException(AirOSException):
 
 
 class AirOSTLSCompatibilityError(AirOSDeviceConnectionError):
-    """The device requires legacy TLS/cipher compaitibility."""
+    """The device requires legacy TLS/cipher compatibility."""

--- a/airos/exceptions.py
+++ b/airos/exceptions.py
@@ -47,3 +47,7 @@ class AirOSUrlNotFoundError(AirOSException):
 
 class AirOSMultipleMatchesFoundException(AirOSException):
     """Raised when multiple devices found for lookup."""
+
+
+class AirOSTLSCompatibilityError(AirOSDeviceConnectionError):
+    """The device requires legacy TLS/cipher compaitibility."""

--- a/airos/helpers.py
+++ b/airos/helpers.py
@@ -12,6 +12,7 @@ from .exceptions import (
     AirOSDataMissingError,
     AirOSDeviceConnectionError,
     AirOSKeyDataMissingError,
+    AirOSTLSCompatibilityError,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +39,9 @@ async def async_get_firmware_data(
     try:
         await detect_device.login()
         device_data = await detect_device.raw_status()
+    except AirOSTLSCompatibilityError:
+        _LOGGER.exception("TLS compatibility error during API call to %s", host)
+        raise
     except (
         AirOSConnectionSetupError,
         AirOSDeviceConnectionError,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.8a0"
+version         = "0.6.8"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.7"
+version         = "0.6.8a0"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"


### PR DESCRIPTION
In addition to #205 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TLS compatibility support for legacy v6 devices to improve connection handling and error clarity for older equipment.

* **Bug Fixes**
  * Improved detection and reporting of TLS handshake failures to surface compatibility issues distinctly.

* **Chores**
  * Version bumped to 0.6.8 and changelog updated with release v0.6.8 (2026-05-26).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->