### PR TITLE
Fix airOS 6 loco M2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.6] - 2026-05-21
+
+### Added
+
+- Add support for NanoStation loco M2
+
 ## [0.6.5] - 2026-04-28
 
 ### Added

--- a/airos/airos6.py
+++ b/airos/airos6.py
@@ -53,6 +53,10 @@ class AirOS6(AirOS[AirOS6Data]):
 
         return derived
 
+    async def login(self) -> None:
+        """Login to airOS v6 devices."""
+        await self._login_v6()
+
     async def update_check(self, force: bool = False) -> dict[str, Any]:
         """Check for firmware updates. Not supported on AirOS6."""
         raise AirOSNotSupportedError("Firmware update check not supported on AirOS6.")

--- a/airos/model_map.py
+++ b/airos/model_map.py
@@ -84,6 +84,7 @@ MANUAL_MODELS: dict[str, str] = {
     "LiteAP AC": "LAP-120",  # Shortened name for airMAX Lite Access Point AC, Issue 137
     "LiteAP GPS": "LAP-GPS",  # Shortened name for airMAX Lite Access Point GPS
     "LiteBeam 5AC 23": "LBE-5AC-23",
+    "NanoStation loco M2": "LocoM2",  # XW firmware version 6 - note the reversed names
     "NanoStation loco M5": "LocoM5",  # XM firmware version 6 - note the reversed names
     "NanoStation loco M900": "LocoM900",  # XM firmware version 6, 900 MHz variant
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.5"
+version         = "0.6.6"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"

--- a/tests/test_model_map.py
+++ b/tests/test_model_map.py
@@ -28,6 +28,11 @@ class TestUispAirOSProductMapper:
         sku = self.mapper.get_sku_by_devmodel("nanostation 5ac loco")
         assert sku == "Loco5AC"
 
+    def test_get_sku_by_devmodel_airos6_reversed_loco_m2(self):
+        """Test the reversed loco M2 model name reported by airOS 6."""
+        sku = self.mapper.get_sku_by_devmodel("NanoStation loco M2 ")
+        assert sku == "LocoM2"
+
     def test_get_sku_by_devmodel_not_found_raises_keyerror(self):
         """Test to raise KeyError when no match (exact or partial) is found."""
         with pytest.raises(

--- a/tests/test_stations6.py
+++ b/tests/test_stations6.py
@@ -70,7 +70,7 @@ async def test_ap_object(
 
 
 @pytest.mark.asyncio
-async def test_login_v6_flow() -> None:
+async def test_login_v6_flow(base_url: str) -> None:
     """Test AirOS v6 XM login flow with manual cookie handling."""
 
     # Create a mock session
@@ -93,7 +93,7 @@ async def test_login_v6_flow() -> None:
     get_index_response = MagicMock()
     get_index_response.__aenter__.return_value = get_index_response
     get_index_response.status = 200
-    get_index_response.url = "http://192.168.1.3/index.cgi"
+    get_index_response.url = f"{base_url}/index.cgi"
 
     # Set side effects for session.request
     session.request.side_effect = [
@@ -104,7 +104,7 @@ async def test_login_v6_flow() -> None:
 
     # Create device
     airos6_device = AirOS6(
-        host="http://192.168.1.3",
+        host=base_url,
         username="ubnt",
         password="ubnt",
         session=session,
@@ -118,4 +118,4 @@ async def test_login_v6_flow() -> None:
     assert airos6_device._auth_cookie == "AIROS_ABC123=xyz789"  # noqa: SLF001
     assert session.request.call_count == 3
     called_urls = [call.args[1] for call in session.request.call_args_list]
-    assert "http://192.168.1.3/api/auth" not in called_urls
+    assert f"{base_url}/api/auth" not in called_urls

--- a/tests/test_stations6.py
+++ b/tests/test_stations6.py
@@ -44,14 +44,14 @@ async def test_ap_object(
     # Create an async mock that can return different values for different calls
     mock_request_json = AsyncMock(
         side_effect=[
-            {},  # First call for login()
-            fixture_data,  # Second call for status()
+            fixture_data,  # status()
         ]
     )
 
     with (
         # Patch the internal method, not the session object
         patch.object(airos6_device, "_request_json", new=mock_request_json),
+        patch.object(airos6_device, "login", new=AsyncMock()),
         # You need to manually set the connected state since login() is mocked
         patch.object(airos6_device, "connected", True),
     ):
@@ -110,10 +110,12 @@ async def test_login_v6_flow() -> None:
         session=session,
     )
 
-    await airos6_device._login_v6()  # noqa: SLF001
+    await airos6_device.login()
 
     # Assertions
     assert airos6_device.connected is True
     assert airos6_device.api_version == 6
     assert airos6_device._auth_cookie == "AIROS_ABC123=xyz789"  # noqa: SLF001
     assert session.request.call_count == 3
+    called_urls = [call.args[1] for call in session.request.call_args_list]
+    assert "http://192.168.1.3/api/auth" not in called_urls


### PR DESCRIPTION
## Summary
- add the airOS 6 reversed devmodel string for NanoStation loco M2 to the model map
- make AirOS6.login call the v6 login flow directly instead of probing /api/auth first
- update tests for the v6 login path and loco M2 SKU mapping

## Context
I reproduced this against two NanoStation loco M2 devices on XW.v6.3.22. airos 0.6.5 can parse their status payload, including opmode 11NGHT20, but the devices report host.devmodel as 'NanoStation loco M2 ' and repeated v6 status polling logs a normal /api/auth 404 before falling back.

## Tests
- python -m pytest tests/test_stations6.py tests/test_model_map.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added explicit public login method for AirOS6 devices, enabling direct control of the authentication flow
  * Extended device support to include NanoStation loco M2

* **Tests**
  * Enhanced unit tests for device model mapping and AirOS6 authentication workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoMPaTech/python-airos/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->