### PR TITLE
Support open wireless security value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.9] - 2026-06-23
+
+### Added
+
+- Add support for open wireless security (tnx @Wackymax)
+
 ## [0.6.8] - 2026-05-26
 
 ### Added

--- a/airos/data.py
+++ b/airos/data.py
@@ -188,6 +188,7 @@ class Wireless6Mode(Enum):
 class Security(Enum):
     """Enum definition."""
 
+    NONE = "none"
     WPA2 = "WPA2"
     # More to be added when known
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.8"
+version         = "0.6.9"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from airos.data import Host, Wireless
+from airos.data import Host, Security, Wireless, Wireless6
 
 
 @pytest.mark.asyncio
@@ -53,3 +53,61 @@ async def test_unknown_enum_values() -> None:
         mock_warning.assert_any_call(
             format_string, "unsupported_security", "Wireless", "security"
         )
+
+
+def test_wireless_security_none_is_supported() -> None:
+    """Test that open/no-security wireless links are supported."""
+    wireless_data = {
+        "mode": "ap-ptp",
+        "ieeemode": "11NGHT20",
+        "security": "none",
+        "other_field": "value",
+    }
+
+    with patch("airos.data.logger.warning") as mock_warning:
+        processed_wireless = Wireless.__pre_deserialize__(wireless_data.copy())
+
+    assert processed_wireless["security"] == "none"
+    mock_warning.assert_not_called()
+
+
+def test_wireless6_security_none_is_supported() -> None:
+    """Test that airOS 6 open/no-security wireless links are supported."""
+    wireless_data = {
+        "essid": "OFFICE-LINK",
+        "hide_essid": 0,
+        "apmac": "9C:05:D6:90:5D:33",
+        "countrycode": 840,
+        "channel": 11,
+        "frequency": "2462 MHz",
+        "dfs": 0,
+        "opmode": "11NGHT20",
+        "antenna": "Built in - 8 dBi",
+        "chains": "2X2",
+        "signal": -59,
+        "rssi": 0,
+        "noisef": -93,
+        "txpower": 23,
+        "ack": 0,
+        "distance": 600,
+        "ccq": 0,
+        "txrate": "",
+        "rxrate": "6",
+        "security": "none",
+        "qos": "",
+        "rstatus": 0,
+        "cac_nol": 0,
+        "nol_chans": 0,
+        "wds": 1,
+        "aprepeater": 0,
+        "chanbw": 20,
+        "mode": "sta",
+    }
+
+    with patch("airos.data.logger.warning") as mock_warning:
+        wireless = Wireless6.from_dict(wireless_data)
+
+    assert wireless.security is Security.NONE
+    assert wireless.frequency == 2462
+    assert wireless.polling.dl_capacity == 6000
+    mock_warning.assert_not_called()


### PR DESCRIPTION
## Summary
- add support for airOS reporting wireless security as `none`
- keep `none` from being treated as an unknown enum value during deserialization
- add regression coverage for both generic wireless preprocessing and airOS 6 `Wireless6` deserialization

## Why
A NanoStation loco M2 running airOS 6.3.22 can report `wireless.security` as `none` when wireless security is disabled/open. The current enum only accepts `WPA2`, so preprocessing removes the value as unknown and `Wireless6.from_dict` then raises `MissingField: Field "security" of type Security is missing`.

## Test
- `uv run --with-requirements requirements-test.txt --with-requirements requirements.txt python -m pytest tests/test_data.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for open wireless networks by introducing a `"none"` security option.

* **Tests**
  * Expanded the test suite to confirm `"none"` security is parsed/preserved correctly and does not trigger warning logging for wireless configuration inputs.

* **Chores**
  * Bumped the package version to **0.6.9** and updated the changelog to reflect the new capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->