### PR TITLE
Add PEP 740 and pin GitHub actions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -70,6 +70,11 @@ jobs:
         run: |
           . venv/bin/activate
           uv build
+      - name: Generate PEP 740 Attestations
+        if: steps.check_package.outputs.should_publish == 'true'
+        uses: astral-sh/attest-action@v1
+        with:
+          dist: dist/
       - name: Publish distribution 📦 to PyPI
         run: |
           . venv/bin/activate

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Get Package Version from pyproject.toml
         id: get_version
         run: |
@@ -60,7 +60,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Prepare uv
         run: |
           pip install uv
@@ -74,7 +74,7 @@ jobs:
         if: steps.check_package.outputs.should_publish == 'true'
         uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
         with:
-          dist: dist/
+          paths: dist/
       - name: Publish distribution 📦 to PyPI
         run: |
           . venv/bin/activate
@@ -89,10 +89,10 @@ jobs:
       contents: write
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Create release tag
         id: tag_release
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             const version = process.env.PACKAGE_VERSION;

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -73,8 +73,6 @@ jobs:
       - name: Generate PEP 740 Attestations
         if: steps.check_package.outputs.should_publish == 'true'
         uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
-        with:
-          paths: dist/
       - name: Publish distribution 📦 to PyPI
         run: |
           . venv/bin/activate

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -72,7 +72,7 @@ jobs:
           uv build
       - name: Generate PEP 740 Attestations
         if: steps.check_package.outputs.should_publish == 'true'
-        uses: astral-sh/attest-action@v1
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
         with:
           dist: dist/
       - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -227,8 +227,6 @@ jobs:
       - name: Generate PEP 740 Attestations
         if: steps.check_package.outputs.should_publish == 'true'
         uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
-        with:
-          paths: dist/
       - name: Publish distribution 📦 to TestPyPI
         if: steps.check_package.outputs.should_publish == 'true'
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -225,7 +225,7 @@ jobs:
           uv build
       - name: Generate PEP 740 Attestations
         if: steps.check_package.outputs.should_publish == 'true'
-        uses: astral-sh/attest-action@v1
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
         with:
           dist: dist/
       - name: Publish distribution 📦 to TestPyPI

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -90,7 +90,7 @@ jobs:
       - commitcheck
     strategy:
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.14"]
     steps:
       - name: Check out committed code
         uses: actions/checkout@v6
@@ -223,6 +223,11 @@ jobs:
         run: |
           . venv/bin/activate
           uv build
+      - name: Generate PEP 740 Attestations
+        if: steps.check_package.outputs.should_publish == 'true'
+        uses: astral-sh/attest-action@v1
+        with:
+          dist: dist/
       - name: Publish distribution 📦 to TestPyPI
         if: steps.check_package.outputs.should_publish == 'true'
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -186,6 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
+        contents: read
         id-token: write
     needs:
       - coverage

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
 
@@ -29,11 +29,11 @@ jobs:
     name: Ruff check and force
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Use python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Prepare python
@@ -65,9 +65,9 @@ jobs:
       - ruff
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Prepare python
@@ -93,9 +93,9 @@ jobs:
         python-version: ["3.14"]
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use python ${{matrix.python-version}}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{matrix.python-version}}
       - name: Prepare python
@@ -109,7 +109,7 @@ jobs:
           . venv/bin/activate
           pytest --log-level info tests/ --cov='airos/'
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage-${{ matrix.python-version }}
           path: .coverage
@@ -124,11 +124,11 @@ jobs:
       - pytest
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - name: Use python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Prepare python
@@ -152,9 +152,9 @@ jobs:
       - mypy
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Prepare python
@@ -164,7 +164,7 @@ jobs:
           . venv/bin/activate
           uv pip install -r requirements.txt -r requirements-test.txt
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: coverage-*
           merge-multiple: true
@@ -176,7 +176,7 @@ jobs:
           coverage report --fail-under=80
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           slug: CoMPaTech/python-airos
@@ -192,9 +192,9 @@ jobs:
       # - mypy
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Prepare python
@@ -227,7 +227,7 @@ jobs:
         if: steps.check_package.outputs.should_publish == 'true'
         uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
         with:
-          dist: dist/
+          paths: dist/
       - name: Publish distribution 📦 to TestPyPI
         if: steps.check_package.outputs.should_publish == 'true'
         run: |
@@ -242,9 +242,9 @@ jobs:
       - coverage
     steps:
       - name: Check out committed code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Prepare python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.10] - 2026-07-05
+
+### Added
+
+- PEP 740 digital attestations (astral workaround until uv publish handles this)
+
 ## [0.6.9] - 2026-06-23
 
 ### Added

--- a/airos/helpers.py
+++ b/airos/helpers.py
@@ -48,7 +48,7 @@ async def async_get_firmware_data(
     ):
         _LOGGER.exception("Error connecting to device at %s", host)
         raise
-    except (AirOSConnectionAuthenticationError, AirOSDataMissingError):
+    except AirOSConnectionAuthenticationError, AirOSDataMissingError:
         _LOGGER.exception("Authentication error connecting to device at %s", host)
         raise
     except AirOSKeyDataMissingError:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.13
+python_version = 3.14
 platform = linux
 plugins = pydantic.mypy, pydantic.v1.mypy
 show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.10a3"
+version         = "0.6.10"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.10a2"
+version         = "0.6.10a3"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.10a1"
+version         = "0.6.10a2"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.9"
+version         = "0.6.10a0"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"
@@ -14,13 +14,12 @@ classifiers     = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3.13",
     "Topic :: Home Automation",
 ]
 maintainers = [
         { name = "CoMPaTech" }
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 dependencies    = [
         "aiohttp>=3.8.0",
         "mashumaro>=3.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name            = "airos"
-version         = "0.6.10a0"
+version         = "0.6.10a1"
 license         = "MIT"
 description     = "Ubiquiti airOS module(s) for Python 3."
 readme          = "README.md"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release publishing now includes digital attestations for distributed packages.

* **Changes**
  * Updated Python support to require Python 3.14.
  * Test and release workflows now run against Python 3.14.
  * Version updated to the next pre-release build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->